### PR TITLE
Make full-stack contract smoke advisory

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/ci-verify.yml
 
   strict-contract-full-stack:
-    name: Strict pinned-contract full-stack smoke
+    name: Advisory pinned-contract full-stack smoke
     runs-on: ubuntu-latest
     needs: verify
     permissions:
@@ -44,7 +44,8 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      - name: Run deterministic contract-fixture smoke test
+      - name: Run advisory deterministic contract-fixture smoke test
+        continue-on-error: true
         run: ./scripts/smoke-test-contract-stack.sh
 
   publish-api:

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -69,8 +69,9 @@ python3 scripts/validate-compatibility-manifest.py
 python3 scripts/test-compatibility-release-gate.py
 ```
 
-CI integration uses `scripts/smoke-test-contract-stack.sh`: local deterministic HTTP fixtures implement the pinned
-Stock Analyst and EDO shapes, and the smoke rejects `DEGRADED`, `WARN`, stale or unvalued holdings. Live Yahoo/GUS
+CI runs `scripts/smoke-test-contract-stack.sh` as an advisory post-verification smoke: local deterministic HTTP
+fixtures implement the pinned Stock Analyst and EDO shapes, and the smoke rejects `DEGRADED`, `WARN`, stale or
+unvalued holdings. A failure remains visible in the step log but does not block image publication. Live Yahoo/GUS
 availability is checked by the upstream projects in their own image canaries. Portfolio does not call the
 LAN-only production hosts from GitHub-hosted runners. An operator with network access can run the same bounded,
 read-only cross-service check with explicit endpoints:


### PR DESCRIPTION
## Summary\n- retain the deterministic full-stack smoke as a visible advisory\n- prevent a smoke failure from blocking image publication\n- document the relaxed gate\n\n## Validation\n- actionlint\n- documentation validation\n- compatibility manifest validation\n- release-gate tests